### PR TITLE
Populate icon fields of supported gates in quis JSON.

### DIFF
--- a/quis/quis.json
+++ b/quis/quis.json
@@ -1,6 +1,24 @@
 {
     "gate_descriptions":
     {
+        "_I":
+        {
+            "icon":
+            {
+                "base": "I",
+                "subscript": null,
+                "superscript": null
+            }
+        },
+        "_H":
+        {
+            "icon":
+            {
+                "base": "H",
+                "subscript": null,
+                "superscript": null
+            }
+        },
         "_X":
         {
             "longName" : "bit flip",
@@ -34,7 +52,259 @@
                         }
                     }
                 }
-            ]
+            ],
+            "icon":
+            {
+                "base": "X",
+                "subscript": null,
+                "superscript": null
+            }
+        },
+        "_X90":
+        {
+            "icon":
+            {
+                "base": "X",
+                "subscript": null,
+                "superscript": "1/2"
+            }
+        },
+        "_mX90":
+        {
+            "icon":
+            {
+                "base": "X",
+                "subscript": null,
+                "superscript": "-1/2"
+            }
+        },
+        "_Y":
+        {
+            "icon":
+            {
+                "base": "Y",
+                "subscript": null,
+                "superscript": null
+            }
+        },
+        "_Y90":
+        {
+            "icon":
+            {
+                "base": "Y",
+                "subscript": null,
+                "superscript": "1/2"
+            }
+        },
+        "_mY90":
+        {
+            "icon":
+            {
+                "base": "Y",
+                "subscript": null,
+                "superscript": "-1/2"
+            }
+        },
+        "_Z":
+        {
+            "icon":
+            {
+                "base": "Z",
+                "subscript": null,
+                "superscript": null
+            }
+        },
+        "_S":
+        {
+            "icon":
+            {
+                "base": "S",
+                "subscript": null,
+                "superscript": null
+            }
+        },
+        "_Sdag":
+        {
+            "icon":
+            {
+                "base": "S",
+                "subscript": null,
+                "superscript": "dagger"
+            }
+        },
+        "_T":
+        {
+            "icon":
+            {
+                "base": "T",
+                "subscript": null,
+                "superscript": null
+            }
+        },
+        "_Tdag":
+        {
+            "icon":
+            {
+                "base": "T",
+                "subscript": null,
+                "superscript": "dagger"
+            }
+        },
+        "_Rx":
+        {
+            "icon":
+            {
+                "base": "R",
+                "subscript": "x",
+                "superscript": null
+            }
+        },
+        "_Ry":
+        {
+            "icon":
+            {
+                "base": "R",
+                "subscript": "y",
+                "superscript": null
+            }
+        },
+        "_Rz":
+        {
+            "icon":
+            {
+                "base": "R",
+                "subscript": "z",
+                "superscript": null
+            }
+        },
+        "_P":
+        {
+            "longName" : null,
+            "description" : null,
+            "numberOfQubits" : 1,
+            "parameters" : [
+                {
+                    "reference" : "theta",
+                    "type" : "float"
+                }
+            ],
+            "semantics" : [
+                {
+                    "type": "blochSphereRotation",
+                    "kwargs":
+                    {
+                        "axis": [0, 0, 1],
+                        "angle":
+                        {
+                            "type": "parameter",
+                            "value": "theta",
+                            "args": null
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "fraction",
+                            "args": [
+                                {
+                                    "type" : "parameter",
+                                    "value" : "theta",
+                                    "args" : null
+                                },
+                                2
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "P",
+                "subscript": "theta",
+                "superscript": null
+            }
+        },
+        "_Pk":
+        {
+            "longName" : null,
+            "description" : null,
+            "numberOfQubits" : 1,
+            "parameters" : [
+                {
+                    "reference" : "k",
+                    "type" : "integer"
+                }
+            ],
+            "semantics" : [
+                {
+                    "type": "blochSphereRotation",
+                    "kwargs":
+                    {
+                        "axis": [0, 0, 1],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "fraction",
+                            "args": [
+                                {
+                                    "type": "operator",
+                                    "value": "mul",
+                                    "args": [
+                                        2,
+                                        {
+                                            "type": "constant",
+                                            "value": "pi",
+                                            "args": null
+                                        }
+                                    ]
+
+                                },
+                                {
+                                    "type": "operator",
+                                    "value": "power",
+                                    "args": [
+                                        2,
+                                        {
+                                            "type": "parameter",
+                                            "value": "k",
+                                            "args": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "fraction",
+                            "args": [
+                                {
+                                    "type" : "constant",
+                                    "value" : "pi",
+                                    "args" : null
+                                },
+                                {
+                                    "type": "operator",
+                                    "value": "power",
+                                    "args": [
+                                        2,
+                                        {
+                                            "type": "parameter",
+                                            "value": "k",
+                                            "args": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "P",
+                "subscript": "k",
+                "superscript": null
+            }
         },
         "_Rxy":
         {
@@ -92,83 +362,60 @@
                 }
             ]
         },
-        "_Rk":
+        "_CNOT":
         {
-            "longName" : null,
+            "longName": "controlled not",
             "description" : null,
-            "numberOfQubits" : 1,
-            "parameters" : [
-                {
-                    "reference" : "k",
-                    "type" : "integer"
-                }
-            ],
+            "numberOfQubits" : 2,
+            "parameters" : null,
             "semantics" : [
                 {
-                    "type": "blochSphereRotation",
+                    "type": "controlledGate",
                     "kwargs":
                     {
-                        "axis": [0, 0, 1],
-                        "angle":
-                        {
-                            "type": "operator",
-                            "value": "fraction", "args": [
-                                {
-                                    "type": "operator",
-                                    "value": "mul",
-                                    "args": [
-                                        2,
-                                        {
-                                            "type": "constant",
-                                            "value": "pi",
-                                            "args": null
-                                        }
-                                    ]
-
-                                },
-                                {
-                                    "type": "operator",
-                                    "value": "power",
-                                    "args": [
-                                        2,
-                                        {
-                                            "type": "parameter",
-                                            "value": "k",
-                                            "args": null
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        "globalPhase":
-                        {
-                            "type": "operator",
-                            "value": "fraction",
-                            "args": [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                {
-                                    "type": "operator",
-                                    "value": "power",
-                                    "args": [
-                                        2,
-                                        {
-                                            "type": "parameter",
-                                            "value": "k",
-                                            "args": null
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
+                        "targetGate": "_X"
                     }
                 }
             ]
         },
-        "_CRk":
+        "_CZ":
+        {
+            "longName": "controlled phase",
+            "description" : null,
+            "numberOfQubits" : 2,
+            "parameters" : null,
+            "semantics" : [
+                {
+                    "type": "controlledGate",
+                    "kwargs":
+                    {
+                        "targetGate": "_Z"
+                    }
+                }
+            ]
+        },
+        "_CP":
+        {
+            "longName": null,
+            "description" : null,
+            "numberOfQubits" : 2,
+            "parameters" : [
+                {
+                    "reference" : "theta",
+                    "type" : "float"
+                }
+            ],
+            "semantics" : [
+                {
+                    "type": "controlledGate",
+                    "kwargs":
+                    {
+                        "targetGate": "_P"
+                    }
+                }
+            ]
+        },
+        "_CPk":
         {
             "longName": null,
             "description" : null,
@@ -184,7 +431,7 @@
                     "type": "controlledGate",
                     "kwargs":
                     {
-                        "targetGate": "_Rk"
+                        "targetGate": "_Pk"
                     }
                 }
             ]
@@ -192,11 +439,29 @@
     },
     "gates":
     {
+        "I": "_I",
+        "H": "_H",
         "X": "_X",
         "x": "_X",
+        "X90": "_X90",
+        "mX90": "_mX90",
+        "Y": "_Y",
+        "Y90": "_Y90",
+        "mY90": "_mY90",
+        "Z": "_Z",
+        "S": "_S",
+        "Sdag": "_Sdag",
+        "T": "_T",
+        "Tdag": "_Tdag",
+        "Rx": "_Rx",
+        "Ry": "_Ry",
+        "Rz": "_Rz",
+        "CNOT": "_CNOT",
+        "CZ": "_CZ",
+        "CR": "_CP",
+        "CRk": "_CPk",
+        "CPk": "_CPk",
         "Rxy": "_Rxy",
-        "rxy": "_Rxy",
-        "CRk": "_CRk",
-        "CPk": "_CRk"
+        "rxy": "_Rxy"
     }
 }

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -22,7 +22,7 @@
         "_X":
         {
             "longName" : "bit flip",
-            "description" : "Pauli X gate. An anticlockwise rotation of pi radians along the x-axis.",
+            "description" : "Pauli X gate. An anticlockwise rotation of $\\pi$ radians along the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
             "semantics" : [
@@ -129,7 +129,7 @@
             {
                 "base": "S",
                 "subscript": null,
-                "superscript": "dagger"
+                "superscript": "$\\dagger$"
             }
         },
         "_T":
@@ -147,7 +147,7 @@
             {
                 "base": "T",
                 "subscript": null,
-                "superscript": "dagger"
+                "superscript": "$\\dagger$"
             }
         },
         "_Rx":
@@ -219,7 +219,7 @@
             "icon":
             {
                 "base": "P",
-                "subscript": "theta",
+                "subscript": "$\\theta$",
                 "superscript": null
             }
         },
@@ -360,7 +360,13 @@
                         "globalPhase" : 0
                     }
                 }
-            ]
+            ],
+            "icon":
+            {
+                "base": "R",
+                "subscript": "xy",
+                "superscript": null
+            }
         },
         "_CNOT":
         {


### PR DESCRIPTION
- Supported gates have been added to the quis JSON.
- The icon field has been added (for each supported gate) and populated.