### PR TITLE
[CQT-211] Add non-unitaries to the QuIS

### DIFF
--- a/quis/__init__.py
+++ b/quis/__init__.py
@@ -1,0 +1,1 @@
+from .quis import as_json_string, as_dict

--- a/quis/main.py
+++ b/quis/main.py
@@ -1,2 +1,0 @@
-if __name__ == "__main__":
-    pass

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -4,7 +4,6 @@
         "_I":
         {
             "title" : "Identity gate",
-            "instructionType": "unitary",
             "description" : "Identity gate.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -28,7 +27,6 @@
         "_H":
         {
             "title" : "Hadamard gate",
-            "instructionType": "unitary",
             "description" : "Hadamard gate.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -69,7 +67,6 @@
         "_X":
         {
             "title" : "Pauli-X gate",
-            "instructionType": "unitary",
             "description" : "Pauli X gate or bit flip. An anticlockwise rotation of $\\pi$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -110,7 +107,6 @@
         "_X90":
         {
             "title" : "X-90 gate",
-            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -162,7 +158,6 @@
         "_mX90":
         {
             "title" : "X-minus-90 gate",
-            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/2$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -214,7 +209,6 @@
         "_Y":
         {
             "title" : "Pauli-Y gate",
-            "instructionType": "unitary",
             "description" : "Pauli Y gate. An anticlockwise rotation of $\\pi$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -255,7 +249,6 @@
         "_Y90":
         {
             "title" : "Y-90 gate",
-            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -307,7 +300,6 @@
         "_mY90":
         {
             "title" : "Y-minus-90 gate",
-            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/2$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -359,7 +351,6 @@
         "_Z":
         {
             "title" : "Pauli-Z gate",
-            "instructionType": "unitary",
             "description" : "Pauli Z gate or phase flip. An anticlockwise rotation of $\\pi$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -400,7 +391,6 @@
         "_S":
         {
             "title" : "S gate",
-            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -448,7 +438,6 @@
         "_Sdag":
         {
             "title" : "S-dagger gate",
-            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/2$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -500,7 +489,6 @@
         "_T":
         {
             "title" : "T gate",
-            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/4$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -548,7 +536,6 @@
         "_Tdag":
         {
             "title" : "T-dagger gate",
-            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/4$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -600,7 +587,6 @@
         "_Rx":
         {
             "title" : "Rx gate",
-            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\theta$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : [
@@ -638,7 +624,6 @@
         "_Ry":
         {
             "title" : "Ry gate",
-            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\theta$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : [
@@ -676,7 +661,6 @@
         "_Rz":
         {
             "title" : "Rz gate",
-            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\theta$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : [
@@ -714,7 +698,6 @@
         "_P":
         {
             "title" : "Phase gate",
-            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 1,
             "parameters" : [
@@ -764,7 +747,6 @@
         "_Pk":
         {
             "title" : "Phase-k gate",
-            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 1,
             "parameters" : [
@@ -851,7 +833,6 @@
         "_Rxy":
         {
             "title" : "Rxy gate",
-            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 1,
             "parameters" : [
@@ -917,7 +898,6 @@
         "_CNOT":
         {
             "title": "CNOT gate",
-            "instructionType": "unitary",
             "description" : "Controlled-not gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
             "numberOfQubits" : 2,
             "parameters" : null,
@@ -929,12 +909,16 @@
                         "targetGate": "_X"
                     }
                 }
-            ]
+            ],
+            "icon":
+            {
+                "base": "cnot",
+                "suffix": null
+            }
         },
         "_CZ":
         {
             "title": "CPhase gate",
-            "instructionType": "unitary",
             "description" : "Controlled-phase gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
             "numberOfQubits" : 2,
             "parameters" : null,
@@ -946,12 +930,16 @@
                         "targetGate": "_Z"
                     }
                 }
-            ]
+            ],
+            "icon":
+            {
+                "base": "controlled",
+                "suffix": null
+            }
         },
         "_CP":
         {
             "title": null,
-            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 2,
             "parameters" : [
@@ -968,12 +956,16 @@
                         "targetGate": "_P"
                     }
                 }
-            ]
+            ],
+            "icon":
+            {
+                "base": "controlled",
+                "suffix": null
+            }
         },
         "_CPk":
         {
             "title": null,
-            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 2,
             "parameters" : [
@@ -990,12 +982,16 @@
                         "targetGate": "_Pk"
                     }
                 }
-            ]
+            ],
+            "icon":
+            {
+                "base": "controlled",
+                "suffix": null
+            }
         },
         "_init":
         {
             "title": "Init",
-            "instructionType": "nonUnitary",
             "description": "Initialization of the qubit in the Z-basis",
             "icon":
             {
@@ -1006,7 +1002,6 @@
         "_measure":
         {
             "title": "Measure",
-            "instructionType": "nonUnitary",
             "description": "Measurement of the qubit in the Z-basis",
             "icon":
             {
@@ -1017,7 +1012,6 @@
         "_measure_X":
         {
             "title": "Measure-X",
-            "instructionType": "nonUnitary",
             "description": "Measurement of the qubit in the X-basis",
             "icon":
             {
@@ -1032,8 +1026,8 @@
         "_reset":
         {
             "title": "Reset",
-            "instructionType": "nonUnitary",
             "description": "Resets qubit to ground state in the Z-basis",
+            "numberOfQubits": 1,
             "icon":
             {
                 "base": "init",
@@ -1043,36 +1037,42 @@
     },
     "instructions":
     {
-        "I": "_I",
-        "H": "_H",
-        "X": "_X",
-        "x": "_X",
-        "X90": "_X90",
-        "mX90": "_mX90",
-        "Y": "_Y",
-        "Y90": "_Y90",
-        "mY90": "_mY90",
-        "Z": "_Z",
-        "S": "_S",
-        "Sdag": "_Sdag",
-        "T": "_T",
-        "Tdag": "_Tdag",
-        "Rx": "_Rx",
-        "Ry": "_Ry",
-        "Rz": "_Rz",
-        "CNOT": "_CNOT",
-        "CZ": "_CZ",
-        "CR": "_CP",
-        "CRk": "_CPk",
-        "CPk": "_CPk",
-        "Rxy": "_Rxy",
-        "rxy": "_Rxy",
-        "init": "_init",
-        "init_Z": "_init",
-        "measure": "_measure",
-        "measure_Z": "_measure",
-        "measure_X": "_measure_X",
-        "reset": "_reset",
-        "reset_Z": "_reset"
+        "unitary":
+        {
+            "I": "_I",
+            "H": "_H",
+            "X": "_X",
+            "x": "_X",
+            "X90": "_X90",
+            "mX90": "_mX90",
+            "Y": "_Y",
+            "Y90": "_Y90",
+            "mY90": "_mY90",
+            "Z": "_Z",
+            "S": "_S",
+            "Sdag": "_Sdag",
+            "T": "_T",
+            "Tdag": "_Tdag",
+            "Rx": "_Rx",
+            "Ry": "_Ry",
+            "Rz": "_Rz",
+            "CNOT": "_CNOT",
+            "CZ": "_CZ",
+            "CR": "_CP",
+            "CRk": "_CPk",
+            "CPk": "_CPk",
+            "Rxy": "_Rxy",
+            "rxy": "_Rxy"
+        },
+        "nonUnitary":
+        {
+            "init": "_init",
+            "init_Z": "_init",
+            "measure": "_measure",
+            "measure_Z": "_measure",
+            "measure_X": "_measure_X",
+            "reset": "_reset",
+            "reset_Z": "_reset"
+        }
     }
 }

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -989,6 +989,19 @@
                 "suffix": null
             }
         },
+        "_SWAP":
+        {
+            "title": "SWAP gate",
+            "description" : "SWAP gate",
+            "numberOfQubits" : 2,
+            "parameters" : null,
+            "semantics" : null,
+            "icon":
+            {
+                "base": "swap",
+                "suffix": null
+            }
+        },
         "_init":
         {
             "title": "Init",
@@ -1062,7 +1075,8 @@
             "CRk": "_CPk",
             "CPk": "_CPk",
             "Rxy": "_Rxy",
-            "rxy": "_Rxy"
+            "rxy": "_Rxy",
+            "SWAP": "_SWAP"
         },
         "nonUnitary":
         {

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -1,9 +1,10 @@
 {
-    "gate_descriptions":
+    "descriptions":
     {
         "_I":
         {
             "title" : "Identity gate",
+            "instructionType": "unitary",
             "description" : "Identity gate.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -27,6 +28,7 @@
         "_H":
         {
             "title" : "Hadamard gate",
+            "instructionType": "unitary",
             "description" : "Hadamard gate.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -67,6 +69,7 @@
         "_X":
         {
             "title" : "Pauli-X gate",
+            "instructionType": "unitary",
             "description" : "Pauli X gate or bit flip. An anticlockwise rotation of $\\pi$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -107,6 +110,7 @@
         "_X90":
         {
             "title" : "X-90 gate",
+            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -148,7 +152,8 @@
             "icon":
             {
                 "base": "X",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": null,
                     "superscript": "half"
                 }
@@ -157,6 +162,7 @@
         "_mX90":
         {
             "title" : "X-minus-90 gate",
+            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/2$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -198,7 +204,8 @@
             "icon":
             {
                 "base": "X",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": null,
                     "superscript": "minushalf"
                 }
@@ -207,6 +214,7 @@
         "_Y":
         {
             "title" : "Pauli-Y gate",
+            "instructionType": "unitary",
             "description" : "Pauli Y gate. An anticlockwise rotation of $\\pi$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -247,6 +255,7 @@
         "_Y90":
         {
             "title" : "Y-90 gate",
+            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -288,7 +297,8 @@
             "icon":
             {
                 "base": "Y",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": null,
                     "superscript": "half"
                 }
@@ -297,6 +307,7 @@
         "_mY90":
         {
             "title" : "Y-minus-90 gate",
+            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/2$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -338,7 +349,8 @@
             "icon":
             {
                 "base": "Y",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": null,
                     "superscript": "minushalf"
                 }
@@ -347,6 +359,7 @@
         "_Z":
         {
             "title" : "Pauli-Z gate",
+            "instructionType": "unitary",
             "description" : "Pauli Z gate or phase flip. An anticlockwise rotation of $\\pi$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -387,6 +400,7 @@
         "_S":
         {
             "title" : "S gate",
+            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -434,6 +448,7 @@
         "_Sdag":
         {
             "title" : "S-dagger gate",
+            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/2$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -475,7 +490,8 @@
             "icon":
             {
                 "base": "S",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": null,
                     "superscript": "dagger"
                 }
@@ -484,6 +500,7 @@
         "_T":
         {
             "title" : "T gate",
+            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\pi/4$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -531,6 +548,7 @@
         "_Tdag":
         {
             "title" : "T-dagger gate",
+            "instructionType": "unitary",
             "description" : "A clockwise rotation of $\\pi/4$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : null,
@@ -572,7 +590,8 @@
             "icon":
             {
                 "base": "T",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": null,
                     "superscript": "dagger"
                 }
@@ -581,6 +600,7 @@
         "_Rx":
         {
             "title" : "Rx gate",
+            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\theta$ radians about the _x_-axis.",
             "numberOfQubits" : 1,
             "parameters" : [
@@ -608,7 +628,8 @@
             "icon":
             {
                 "base": "R",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": "x",
                     "superscript": null
                 }
@@ -617,6 +638,7 @@
         "_Ry":
         {
             "title" : "Ry gate",
+            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\theta$ radians about the _y_-axis.",
             "numberOfQubits" : 1,
             "parameters" : [
@@ -644,7 +666,8 @@
             "icon":
             {
                 "base": "R",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": "y",
                     "superscript": null
                 }
@@ -653,6 +676,7 @@
         "_Rz":
         {
             "title" : "Rz gate",
+            "instructionType": "unitary",
             "description" : "An anticlockwise rotation of $\\theta$ radians about the _z_-axis.",
             "numberOfQubits" : 1,
             "parameters" : [
@@ -680,7 +704,8 @@
             "icon":
             {
                 "base": "R",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": "z",
                     "superscript": null
                 }
@@ -689,6 +714,7 @@
         "_P":
         {
             "title" : "Phase gate",
+            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 1,
             "parameters" : [
@@ -728,7 +754,8 @@
             "icon":
             {
                 "base": "P",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": "theta",
                     "superscript": null
                 }
@@ -737,6 +764,7 @@
         "_Pk":
         {
             "title" : "Phase-k gate",
+            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 1,
             "parameters" : [
@@ -813,7 +841,8 @@
             "icon":
             {
                 "base": "P",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": "k",
                     "superscript": null
                 }
@@ -822,6 +851,7 @@
         "_Rxy":
         {
             "title" : "Rxy gate",
+            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 1,
             "parameters" : [
@@ -877,7 +907,8 @@
             "icon":
             {
                 "base": "R",
-                "suffix": {
+                "suffix":
+                {
                     "subscript": "xy",
                     "superscript": null
                 }
@@ -886,6 +917,7 @@
         "_CNOT":
         {
             "title": "CNOT gate",
+            "instructionType": "unitary",
             "description" : "Controlled-not gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
             "numberOfQubits" : 2,
             "parameters" : null,
@@ -902,6 +934,7 @@
         "_CZ":
         {
             "title": "CPhase gate",
+            "instructionType": "unitary",
             "description" : "Controlled-phase gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
             "numberOfQubits" : 2,
             "parameters" : null,
@@ -918,6 +951,7 @@
         "_CP":
         {
             "title": null,
+            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 2,
             "parameters" : [
@@ -939,6 +973,7 @@
         "_CPk":
         {
             "title": null,
+            "instructionType": "unitary",
             "description" : null,
             "numberOfQubits" : 2,
             "parameters" : [
@@ -956,9 +991,57 @@
                     }
                 }
             ]
+        },
+        "_init":
+        {
+            "title": "Init",
+            "instructionType": "nonUnitary",
+            "description": "Initialization of the qubit in the Z-basis",
+            "icon":
+            {
+                "base": "init",
+                "suffix": null
+            }
+        },
+        "_measure":
+        {
+            "title": "Measure",
+            "instructionType": "nonUnitary",
+            "description": "Measurement of the qubit in the Z-basis",
+            "icon":
+            {
+                "base": "measure",
+                "suffix": null
+            }
+        },
+        "_measure_X":
+        {
+            "title": "Measure-X",
+            "instructionType": "nonUnitary",
+            "description": "Measurement of the qubit in the X-basis",
+            "icon":
+            {
+                "base": "measure",
+                "suffix":
+                {
+                    "subscript" : "X",
+                    "superscript" : null
+                }
+            }
+        },
+        "_reset":
+        {
+            "title": "Reset",
+            "instructionType": "nonUnitary",
+            "description": "Resets qubit to ground state in the Z-basis",
+            "icon":
+            {
+                "base": "init",
+                "suffix": null
+            }
         }
     },
-    "gates":
+    "instructions":
     {
         "I": "_I",
         "H": "_H",
@@ -983,6 +1066,13 @@
         "CRk": "_CPk",
         "CPk": "_CPk",
         "Rxy": "_Rxy",
-        "rxy": "_Rxy"
+        "rxy": "_Rxy",
+        "init": "_init",
+        "init_Z": "_init",
+        "measure": "_measure",
+        "measure_Z": "_measure",
+        "measure_X": "_measure_X",
+        "reset": "_reset",
+        "reset_Z": "_reset"
     }
 }

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -941,7 +941,7 @@
             "numberOfQubits": 1,
             "icon":
             {
-                "base": "init",
+                "base": "reset",
                 "suffix": null
             }
         }

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -830,71 +830,6 @@
                 }
             }
         },
-        "_Rxy":
-        {
-            "title" : "Rxy gate",
-            "description" : null,
-            "numberOfQubits" : 1,
-            "parameters" : [
-                {
-                    "reference" : "theta",
-                    "type" : "float"
-                },
-                {
-                    "reference" : "phi",
-                    "type" : "float"
-                }
-            ],
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [
-                            {
-                                "type" : "operator",
-                                "value" : "cos",
-                                "args" : [
-                                    {
-                                        "type" : "parameter",
-                                        "value" : "phi",
-                                        "args": null
-                                    }
-                                ]
-                            },
-                            {
-                                "type" : "operator",
-                                "value" : "sin",
-                                "args" : [
-                                    {
-                                        "type" : "parameter",
-                                        "value" : "phi",
-                                        "args": null
-                                    }
-                                ]
-                            },
-                            0
-                        ],
-                        "angle" :
-                        {
-                            "type" : "parameter",
-                            "value" : "theta",
-                            "args": null
-                        },
-                        "globalPhase" : 0
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "R",
-                "suffix":
-                {
-                    "subscript": "xy",
-                    "superscript": null
-                }
-            }
-        },
         "_CNOT":
         {
             "title": "CNOT gate",
@@ -937,7 +872,7 @@
                 "suffix": null
             }
         },
-        "_CP":
+        "_CR":
         {
             "title": null,
             "description" : null,
@@ -963,7 +898,7 @@
                 "suffix": null
             }
         },
-        "_CPk":
+        "_CRk":
         {
             "title": null,
             "description" : null,
@@ -989,29 +924,6 @@
                 "suffix": null
             }
         },
-        "_SWAP":
-        {
-            "title": "SWAP gate",
-            "description" : "SWAP gate",
-            "numberOfQubits" : 2,
-            "parameters" : null,
-            "semantics" : null,
-            "icon":
-            {
-                "base": "swap",
-                "suffix": null
-            }
-        },
-        "_init":
-        {
-            "title": "Init",
-            "description": "Initialization of the qubit in the Z-basis",
-            "icon":
-            {
-                "base": "init",
-                "suffix": null
-            }
-        },
         "_measure":
         {
             "title": "Measure",
@@ -1020,20 +932,6 @@
             {
                 "base": "measure",
                 "suffix": null
-            }
-        },
-        "_measure_X":
-        {
-            "title": "Measure-X",
-            "description": "Measurement of the qubit in the X-basis",
-            "icon":
-            {
-                "base": "measure",
-                "suffix":
-                {
-                    "subscript" : "X",
-                    "superscript" : null
-                }
             }
         },
         "_reset":
@@ -1055,7 +953,6 @@
             "I": "_I",
             "H": "_H",
             "X": "_X",
-            "x": "_X",
             "X90": "_X90",
             "mX90": "_mX90",
             "Y": "_Y",
@@ -1071,22 +968,13 @@
             "Rz": "_Rz",
             "CNOT": "_CNOT",
             "CZ": "_CZ",
-            "CR": "_CP",
-            "CRk": "_CPk",
-            "CPk": "_CPk",
-            "Rxy": "_Rxy",
-            "rxy": "_Rxy",
-            "SWAP": "_SWAP"
+            "CR": "_CR",
+            "CRk": "_CRk"
         },
         "nonUnitary":
         {
-            "init": "_init",
-            "init_Z": "_init",
             "measure": "_measure",
-            "measure_Z": "_measure",
-            "measure_X": "_measure_X",
-            "reset": "_reset",
-            "reset_Z": "_reset"
+            "reset": "_reset"
         }
     }
 }

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -1,56 +1,140 @@
 {
     "descriptions":
     {
-        "_I":
+        "_CNOT":
         {
-            "title" : "Identity gate",
-            "description" : "Identity gate.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
+            "title": "CNOT gate",
+            "description": "Controlled-not gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
+            "numberOfQubits": 2,
+            "parameters": null,
+            "semantics":
+            [
                 {
-                    "type" : "blochSphereRotation",
-                    "args" :
+                    "type": "controlledGate",
+                    "args":
                     {
-                        "axis" : [0, 0, 1],
-                        "angle" : 0,
-                        "globalPhase" : 0
+                        "targetGate": "_X"
                     }
                 }
             ],
             "icon":
             {
-                "base": "I",
+                "base": "cnot",
+                "suffix": null
+            }
+        },
+        "_CR":
+        {
+            "title": null,
+            "description": null,
+            "numberOfQubits": 2,
+            "parameters":
+            [
+                {
+                    "reference": "theta",
+                    "type": "float"
+                }
+            ],
+            "semantics":
+            [
+                {
+                    "type": "controlledGate",
+                    "args":
+                    {
+                        "targetGate": "_P"
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "controlled",
+                "suffix": null
+            }
+        },
+        "_CRk":
+        {
+            "title": null,
+            "description": null,
+            "numberOfQubits": 2,
+            "parameters":
+            [
+                {
+                    "reference": "k",
+                    "type": "integer"
+                }
+            ],
+            "semantics":
+            [
+                {
+                    "type": "controlledGate",
+                    "args":
+                    {
+                        "targetGate": "_Pk"
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "controlled",
+                "suffix": null
+            }
+        },
+        "_CZ":
+        {
+            "title": "CPhase gate",
+            "description": "Controlled-phase gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
+            "numberOfQubits": 2,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "controlledGate",
+                    "args":
+                    {
+                        "targetGate": "_Z"
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "controlled",
                 "suffix": null
             }
         },
         "_H":
         {
-            "title" : "Hadamard gate",
-            "description" : "Hadamard gate.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
+            "title": "Hadamard gate",
+            "description": "Hadamard gate.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
                 {
-                    "type" : "blochSphereRotation",
-                    "args" :
+                    "type": "blochSphereRotation",
+                    "args":
                     {
-                        "axis" : [1, 0, 1],
-                        "angle" :
+                        "axis":
+                        [
+                            1,
+                            0,
+                            1
+                        ],
+                        "angle":
                         {
-                            "type" : "constant",
-                            "value" : "pi",
-                            "args" : null
+                            "type": "constant",
+                            "value": "pi",
+                            "args": null
                         },
-                        "globalPhase" :
+                        "globalPhase":
                         {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
                                 {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
                                 },
                                 2
                             ]
@@ -64,654 +148,59 @@
                 "suffix": null
             }
         },
-        "_X":
+        "_I":
         {
-            "title" : "Pauli-X gate",
-            "description" : "Pauli X gate or bit flip. An anticlockwise rotation of $\\pi$ radians about the _x_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [1, 0, 0],
-                        "angle" :
-                        {
-                            "type" : "constant",
-                            "value" : "pi",
-                            "args" : null
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                2
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "X",
-                "suffix": null
-            }
-        },
-        "_X90":
-        {
-            "title" : "X-90 gate",
-            "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _x_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [1, 0, 0],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                2
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "X",
-                "suffix":
-                {
-                    "subscript": null,
-                    "superscript": "half"
-                }
-            }
-        },
-        "_mX90":
-        {
-            "title" : "X-minus-90 gate",
-            "description" : "A clockwise rotation of $\\pi/2$ radians about the _x_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [1, 0, 0],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -2
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "X",
-                "suffix":
-                {
-                    "subscript": null,
-                    "superscript": "minushalf"
-                }
-            }
-        },
-        "_Y":
-        {
-            "title" : "Pauli-Y gate",
-            "description" : "Pauli Y gate. An anticlockwise rotation of $\\pi$ radians about the _y_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 1, 0],
-                        "angle" :
-                        {
-                            "type" : "constant",
-                            "value" : "pi",
-                            "args" : null
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                2
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "Y",
-                "suffix": null
-            }
-        },
-        "_Y90":
-        {
-            "title" : "Y-90 gate",
-            "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _y_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 1, 0],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                2
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "Y",
-                "suffix":
-                {
-                    "subscript": null,
-                    "superscript": "half"
-                }
-            }
-        },
-        "_mY90":
-        {
-            "title" : "Y-minus-90 gate",
-            "description" : "A clockwise rotation of $\\pi/2$ radians about the _y_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 1, 0],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -2
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "Y",
-                "suffix":
-                {
-                    "subscript": null,
-                    "superscript": "minushalf"
-                }
-            }
-        },
-        "_Z":
-        {
-            "title" : "Pauli-Z gate",
-            "description" : "Pauli Z gate or phase flip. An anticlockwise rotation of $\\pi$ radians about the _z_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 0, 1],
-                        "angle" :
-                        {
-                            "type" : "constant",
-                            "value" : "pi",
-                            "args" : null
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                2
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "Z",
-                "suffix": null
-            }
-        },
-        "_S":
-        {
-            "title" : "S gate",
-            "description" : "An anticlockwise rotation of $\\pi/2$ radians about the _z_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 0, 1],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                2
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "S",
-                "suffix": null
-            }
-        },
-        "_Sdag":
-        {
-            "title" : "S-dagger gate",
-            "description" : "A clockwise rotation of $\\pi/2$ radians about the _z_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 0, 1],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -2
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "S",
-                "suffix":
-                {
-                    "subscript": null,
-                    "superscript": "dagger"
-                }
-            }
-        },
-        "_T":
-        {
-            "title" : "T gate",
-            "description" : "An anticlockwise rotation of $\\pi/4$ radians about the _z_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 0, 1],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                4
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                8
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "T",
-                "suffix": null
-            }
-        },
-        "_Tdag":
-        {
-            "title" : "T-dagger gate",
-            "description" : "A clockwise rotation of $\\pi/4$ radians about the _z_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : null,
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 0, 1],
-                        "angle" :
-                        {
-                            "type": "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -4
-                            ]
-                        },
-                        "globalPhase" :
-                        {
-                            "type" : "operator",
-                            "value" : "frac",
-                            "args" : [
-                                {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
-                                },
-                                -8
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "T",
-                "suffix":
-                {
-                    "subscript": null,
-                    "superscript": "dagger"
-                }
-            }
-        },
-        "_Rx":
-        {
-            "title" : "Rx gate",
-            "description" : "An anticlockwise rotation of $\\theta$ radians about the _x_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : [
-                {
-                    "reference" : "theta",
-                    "type" : "float"
-                }
-            ],
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [1, 0, 0],
-                        "angle" :
-                        {
-                            "type" : "parameter",
-                            "value" : "theta",
-                            "args": null
-                        },
-                        "globalPhase" : 0
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "R",
-                "suffix":
-                {
-                    "subscript": "x",
-                    "superscript": null
-                }
-            }
-        },
-        "_Ry":
-        {
-            "title" : "Ry gate",
-            "description" : "An anticlockwise rotation of $\\theta$ radians about the _y_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : [
-                {
-                    "reference" : "theta",
-                    "type" : "float"
-                }
-            ],
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 1, 0],
-                        "angle" :
-                        {
-                            "type" : "parameter",
-                            "value" : "theta",
-                            "args": null
-                        },
-                        "globalPhase" : 0
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "R",
-                "suffix":
-                {
-                    "subscript": "y",
-                    "superscript": null
-                }
-            }
-        },
-        "_Rz":
-        {
-            "title" : "Rz gate",
-            "description" : "An anticlockwise rotation of $\\theta$ radians about the _z_-axis.",
-            "numberOfQubits" : 1,
-            "parameters" : [
-                {
-                    "reference" : "theta",
-                    "type" : "float"
-                }
-            ],
-            "semantics" : [
-                {
-                    "type" : "blochSphereRotation",
-                    "args" :
-                    {
-                        "axis" : [0, 0, 1],
-                        "angle" :
-                        {
-                            "type" : "parameter",
-                            "value" : "theta",
-                            "args": null
-                        },
-                        "globalPhase" : 0
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "R",
-                "suffix":
-                {
-                    "subscript": "z",
-                    "superscript": null
-                }
-            }
-        },
-        "_P":
-        {
-            "title" : "Phase gate",
-            "description" : null,
-            "numberOfQubits" : 1,
-            "parameters" : [
-                {
-                    "reference" : "theta",
-                    "type" : "float"
-                }
-            ],
-            "semantics" : [
+            "title": "Identity gate",
+            "description": "Identity gate.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
                 {
                     "type": "blochSphereRotation",
                     "args":
                     {
-                        "axis": [0, 0, 1],
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
+                        "angle": 0,
+                        "globalPhase": 0
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "I",
+                "suffix": null
+            }
+        },
+        "_P":
+        {
+            "title": "Phase gate",
+            "description": null,
+            "numberOfQubits": 1,
+            "parameters":
+            [
+                {
+                    "reference": "theta",
+                    "type": "float"
+                }
+            ],
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
                         "angle":
                         {
                             "type": "parameter",
@@ -722,11 +211,12 @@
                         {
                             "type": "operator",
                             "value": "fraction",
-                            "args": [
+                            "args":
+                            [
                                 {
-                                    "type" : "parameter",
-                                    "value" : "theta",
-                                    "args" : null
+                                    "type": "parameter",
+                                    "value": "theta",
+                                    "args": null
                                 },
                                 2
                             ]
@@ -746,30 +236,39 @@
         },
         "_Pk":
         {
-            "title" : "Phase-k gate",
-            "description" : null,
-            "numberOfQubits" : 1,
-            "parameters" : [
+            "title": "Phase-k gate",
+            "description": null,
+            "numberOfQubits": 1,
+            "parameters":
+            [
                 {
-                    "reference" : "k",
-                    "type" : "integer"
+                    "reference": "k",
+                    "type": "integer"
                 }
             ],
-            "semantics" : [
+            "semantics":
+            [
                 {
                     "type": "blochSphereRotation",
                     "args":
                     {
-                        "axis": [0, 0, 1],
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
                         "angle":
                         {
                             "type": "operator",
                             "value": "fraction",
-                            "args": [
+                            "args":
+                            [
                                 {
                                     "type": "operator",
                                     "value": "mul",
-                                    "args": [
+                                    "args":
+                                    [
                                         2,
                                         {
                                             "type": "constant",
@@ -777,12 +276,12 @@
                                             "args": null
                                         }
                                     ]
-
                                 },
                                 {
                                     "type": "operator",
                                     "value": "power",
-                                    "args": [
+                                    "args":
+                                    [
                                         2,
                                         {
                                             "type": "parameter",
@@ -797,16 +296,18 @@
                         {
                             "type": "operator",
                             "value": "fraction",
-                            "args": [
+                            "args":
+                            [
                                 {
-                                    "type" : "constant",
-                                    "value" : "pi",
-                                    "args" : null
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
                                 },
                                 {
                                     "type": "operator",
                                     "value": "power",
-                                    "args": [
+                                    "args":
+                                    [
                                         2,
                                         {
                                             "type": "parameter",
@@ -830,98 +331,741 @@
                 }
             }
         },
-        "_CNOT":
+        "_Rx":
         {
-            "title": "CNOT gate",
-            "description" : "Controlled-not gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
-            "numberOfQubits" : 2,
-            "parameters" : null,
-            "semantics" : [
+            "title": "Rx gate",
+            "description": "An anticlockwise rotation of $\\theta$ radians about the _x_-axis.",
+            "numberOfQubits": 1,
+            "parameters":
+            [
                 {
-                    "type": "controlledGate",
+                    "reference": "theta",
+                    "type": "float"
+                }
+            ],
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
                     "args":
                     {
-                        "targetGate": "_X"
+                        "axis":
+                        [
+                            1,
+                            0,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "parameter",
+                            "value": "theta",
+                            "args": null
+                        },
+                        "globalPhase": 0
                     }
                 }
             ],
             "icon":
             {
-                "base": "cnot",
+                "base": "R",
+                "suffix":
+                {
+                    "subscript": "x",
+                    "superscript": null
+                }
+            }
+        },
+        "_Ry":
+        {
+            "title": "Ry gate",
+            "description": "An anticlockwise rotation of $\\theta$ radians about the _y_-axis.",
+            "numberOfQubits": 1,
+            "parameters":
+            [
+                {
+                    "reference": "theta",
+                    "type": "float"
+                }
+            ],
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            1,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "parameter",
+                            "value": "theta",
+                            "args": null
+                        },
+                        "globalPhase": 0
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "R",
+                "suffix":
+                {
+                    "subscript": "y",
+                    "superscript": null
+                }
+            }
+        },
+        "_Rz":
+        {
+            "title": "Rz gate",
+            "description": "An anticlockwise rotation of $\\theta$ radians about the _z_-axis.",
+            "numberOfQubits": 1,
+            "parameters":
+            [
+                {
+                    "reference": "theta",
+                    "type": "float"
+                }
+            ],
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
+                        "angle":
+                        {
+                            "type": "parameter",
+                            "value": "theta",
+                            "args": null
+                        },
+                        "globalPhase": 0
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "R",
+                "suffix":
+                {
+                    "subscript": "z",
+                    "superscript": null
+                }
+            }
+        },
+        "_S":
+        {
+            "title": "S gate",
+            "description": "An anticlockwise rotation of $\\pi/2$ radians about the _z_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                4
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "S",
                 "suffix": null
             }
         },
-        "_CZ":
+        "_Sdag":
         {
-            "title": "CPhase gate",
-            "description" : "Controlled-phase gate, whereby the first qubit is the control qubit and the second qubit is the target qubit.",
-            "numberOfQubits" : 2,
-            "parameters" : null,
-            "semantics" : [
+            "title": "S-dagger gate",
+            "description": "A clockwise rotation of $\\pi/2$ radians about the _z_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
                 {
-                    "type": "controlledGate",
+                    "type": "blochSphereRotation",
                     "args":
                     {
-                        "targetGate": "_Z"
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -4
+                            ]
+                        }
                     }
                 }
             ],
             "icon":
             {
-                "base": "controlled",
+                "base": "S",
+                "suffix":
+                {
+                    "subscript": null,
+                    "superscript": "dagger"
+                }
+            }
+        },
+        "_T":
+        {
+            "title": "T gate",
+            "description": "An anticlockwise rotation of $\\pi/4$ radians about the _z_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                4
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                8
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "T",
                 "suffix": null
             }
         },
-        "_CR":
+        "_Tdag":
         {
-            "title": null,
-            "description" : null,
-            "numberOfQubits" : 2,
-            "parameters" : [
+            "title": "T-dagger gate",
+            "description": "A clockwise rotation of $\\pi/4$ radians about the _z_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
                 {
-                    "reference" : "theta",
-                    "type" : "float"
-                }
-            ],
-            "semantics" : [
-                {
-                    "type": "controlledGate",
+                    "type": "blochSphereRotation",
                     "args":
                     {
-                        "targetGate": "_P"
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -4
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -8
+                            ]
+                        }
                     }
                 }
             ],
             "icon":
             {
-                "base": "controlled",
+                "base": "T",
+                "suffix":
+                {
+                    "subscript": null,
+                    "superscript": "dagger"
+                }
+            }
+        },
+        "_X":
+        {
+            "title": "Pauli-X gate",
+            "description": "Pauli X gate or bit flip. An anticlockwise rotation of $\\pi$ radians about the _x_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            1,
+                            0,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "constant",
+                            "value": "pi",
+                            "args": null
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                2
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "X",
                 "suffix": null
             }
         },
-        "_CRk":
+        "_X90":
         {
-            "title": null,
-            "description" : null,
-            "numberOfQubits" : 2,
-            "parameters" : [
+            "title": "X-90 gate",
+            "description": "An anticlockwise rotation of $\\pi/2$ radians about the _x_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
                 {
-                    "reference" : "k",
-                    "type" : "integer"
-                }
-            ],
-            "semantics" : [
-                {
-                    "type": "controlledGate",
+                    "type": "blochSphereRotation",
                     "args":
                     {
-                        "targetGate": "_Pk"
+                        "axis":
+                        [
+                            1,
+                            0,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                4
+                            ]
+                        }
                     }
                 }
             ],
             "icon":
             {
-                "base": "controlled",
+                "base": "X",
+                "suffix":
+                {
+                    "subscript": null,
+                    "superscript": "half"
+                }
+            }
+        },
+        "_Y":
+        {
+            "title": "Pauli-Y gate",
+            "description": "Pauli Y gate. An anticlockwise rotation of $\\pi$ radians about the _y_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            1,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "constant",
+                            "value": "pi",
+                            "args": null
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                2
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "Y",
                 "suffix": null
+            }
+        },
+        "_Y90":
+        {
+            "title": "Y-90 gate",
+            "description": "An anticlockwise rotation of $\\pi/2$ radians about the _y_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            1,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                4
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "Y",
+                "suffix":
+                {
+                    "subscript": null,
+                    "superscript": "half"
+                }
+            }
+        },
+        "_Z":
+        {
+            "title": "Pauli-Z gate",
+            "description": "Pauli Z gate or phase flip. An anticlockwise rotation of $\\pi$ radians about the _z_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            0,
+                            1
+                        ],
+                        "angle":
+                        {
+                            "type": "constant",
+                            "value": "pi",
+                            "args": null
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                2
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "Z",
+                "suffix": null
+            }
+        },
+        "_mX90":
+        {
+            "title": "X-minus-90 gate",
+            "description": "A clockwise rotation of $\\pi/2$ radians about the _x_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            1,
+                            0,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -4
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "X",
+                "suffix":
+                {
+                    "subscript": null,
+                    "superscript": "minushalf"
+                }
+            }
+        },
+        "_mY90":
+        {
+            "title": "Y-minus-90 gate",
+            "description": "A clockwise rotation of $\\pi/2$ radians about the _y_-axis.",
+            "numberOfQubits": 1,
+            "parameters": null,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            1,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi",
+                                    "args": null
+                                },
+                                -4
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "Y",
+                "suffix":
+                {
+                    "subscript": null,
+                    "superscript": "minushalf"
+                }
             }
         },
         "_measure":
@@ -950,26 +1094,26 @@
     {
         "unitary":
         {
-            "I": "_I",
+            "CNOT": "_CNOT",
+            "CR": "_CR",
+            "CRk": "_CRk",
+            "CZ": "_CZ",
             "H": "_H",
-            "X": "_X",
-            "X90": "_X90",
-            "mX90": "_mX90",
-            "Y": "_Y",
-            "Y90": "_Y90",
-            "mY90": "_mY90",
-            "Z": "_Z",
+            "I": "_I",
+            "Rx": "_Rx",
+            "Ry": "_Ry",
+            "Rz": "_Rz",
             "S": "_S",
             "Sdag": "_Sdag",
             "T": "_T",
             "Tdag": "_Tdag",
-            "Rx": "_Rx",
-            "Ry": "_Ry",
-            "Rz": "_Rz",
-            "CNOT": "_CNOT",
-            "CZ": "_CZ",
-            "CR": "_CR",
-            "CRk": "_CRk"
+            "X": "_X",
+            "X90": "_X90",
+            "Y": "_Y",
+            "Y90": "_Y90",
+            "Z": "_Z",
+            "mX90": "_mX90",
+            "mY90": "_mY90"
         },
         "nonUnitary":
         {

--- a/quis/quis.py
+++ b/quis/quis.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+quis_json = Path(__file__).parent / "quis.json"
+
+def as_json_string() -> str:
+    """Loads the QuIS JSON file content and returns it as a JSON string."""
+
+    with open(quis_json) as file:
+        quis = file.read()
+    return quis
+
+def as_dict() -> dict:
+    """Loads the QuIS JSON file content and returns it as a Python dictionary."""
+
+    with open(quis_json) as file:
+        quis = json.load(file)
+    return quis
+
+
+# if __name__ == "__main__":

--- a/quis/quis.py
+++ b/quis/quis.py
@@ -16,6 +16,3 @@ def as_dict() -> dict:
     with open(quis_json) as file:
         quis = json.load(file)
     return quis
-
-
-# if __name__ == "__main__":


### PR DESCRIPTION
- Add non-unitary instructions to the quis (as requested by the QI frontend).
  - an extra field has been added to the descriptions (`instructionType`) to distinguish between unitaries (gates) and (non-unitaries)
- Add functionality to expose the quis through python call.