### PR TITLE
[CQT-255] Add instructions and directives to QuIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+### Types of changes:
+* **Added** for new features.
+* **Changed** for changes in existing functionality.
+* **Deprecated** for soon-to-be removed features.
+* **Removed** for now removed features.
+* **Fixed** for any bug fixes.
+* **Security** in case of vulnerabilities.
+
+## [ 0.1.0 ] - [ xxxx-yy-zz ]
+
+### Added
+
+- `init` non-unitary instruction description to `quis.json`
+- `SWAP` two-qubit unitary description to `quis.json`
+- `barrier` and `wait` control instruction descriptions to `quis.json`
+- `control` field to instructions in `quis.json`

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -104,17 +104,6 @@
                 "targetGate": "_Z"
             }
         },
-        "_Fredkin":
-        {
-            "title": "Fredkin gate",
-           "description": "Controlled SWAP",
-            "numberOfQubits": 3,
-            "semantics": [],
-            "icon":
-            {
-                "base": "C-SWAP"
-            }
-        },
         "_H":
         {
             "title": "Hadamard gate",
@@ -195,45 +184,6 @@
                 "base": "init"
             }
         },
-        "_init_X":
-        {
-            "title": "Init-X",
-            "description": "Initializes qubits in the X-basis",
-            "numberOfQubits": 1,
-            "icon":
-            {
-                "base": "init",
-                "suffix": {
-                    "subscript": "X"
-                }
-            }
-        },
-        "_init_Y":
-        {
-            "title": "Init-Y",
-            "description": "Initializes qubits in the Y-basis",
-            "numberOfQubits": 1,
-            "icon":
-            {
-                "base": "init",
-                "suffix": {
-                    "subscript": "Y"
-                }
-            }
-        },
-        "_init_Z":
-        {
-            "title": "Init-Z",
-            "description": "Initializes qubits in the Z-basis",
-            "numberOfQubits": 1,
-            "icon":
-            {
-                "base": "init",
-                "suffix": {
-                    "subscript": "Z"
-                }
-            }
-        },
         "_measure":
         {
             "title": "Measure",
@@ -241,42 +191,6 @@
             "icon":
             {
                 "base": "measure"
-            }
-        },
-        "_measure_X":
-        {
-            "title": "Measure-X",
-            "description": "Measurement of the qubit in the X-basis",
-            "icon":
-            {
-                "base": "measure",
-                "suffix": {
-                    "subscript": "X"
-                }
-            }
-        },
-        "_measure_Y":
-        {
-            "title": "Measure-Y",
-            "description": "Measurement of the qubit in the Y-basis",
-            "icon":
-            {
-                "base": "measure",
-                "suffix": {
-                    "subscript": "Y"
-                }
-            }
-        },
-        "_measure_Z":
-        {
-            "title": "Measure-Z",
-            "description": "Measurement of the qubit in the Z-basis",
-            "icon":
-            {
-                "base": "measure",
-                "suffix": {
-                    "subscript": "Z"
-                }
             }
         },
         "_mX90":
@@ -543,45 +457,6 @@
                 "base": "reset"
             }
         },
-        "_reset_X":
-        {
-            "title": "Reset-X",
-            "description": "Resets qubit to ground state in the X-basis",
-            "numberOfQubits": 1,
-            "icon":
-            {
-                "base": "reset",
-                "suffix": {
-                    "subscript": "X"
-                }
-            }
-        },
-        "_reset_Y":
-        {
-            "title": "Reset-Y",
-            "description": "Resets qubit to ground state in the Y-basis",
-            "numberOfQubits": 1,
-            "icon":
-            {
-                "base": "reset",
-                "suffix": {
-                    "subscript": "Y"
-                }
-            }
-        },
-        "_reset_Z":
-        {
-            "title": "Reset-Z",
-            "description": "Resets qubit to ground state in the Z-basis",
-            "numberOfQubits": 1,
-            "icon":
-            {
-                "base": "reset",
-                "suffix": {
-                    "subscript": "Z"
-                }
-            }
-        },
         "_Rx":
         {
             "title": "Rx gate",
@@ -814,36 +689,6 @@
                 }
             }
         },
-        "_sqrtSWAP":
-        {
-            "title": "sqrtSWAP gate",
-            "description": "Square root of SWAPs.",
-            "numberOfQubits": 2,
-            "semantics":
-            [
-                {
-                    "type": "matrixGate",
-                    "args":
-                    {
-                        "matrix":
-                        [
-                            [1, 0, 0, 0],
-                            [0, (1 + i) / 2, (1 - i) / 2, 0],
-                            [0, (1 - i) / 2, (1 + i) / 2, 0],
-                            [0, 0, 0, 1]
-                        ]
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "SWAP",
-                "suffix":
-                {
-                    "superscript": "half"
-                }
-            }
-        },
         "_SWAP":
         {
             "title": "SWAP gate",
@@ -867,7 +712,7 @@
             ],
             "icon":
             {
-                "base": "swap",
+                "base": "swap"
             }
         },
         "_T":
@@ -974,17 +819,6 @@
                 {
                     "superscript": "dagger"
                 }
-            }
-        },
-        "_Toffoli":
-        {
-            "title": "Toffoli gate",
-           "description": "Controlled controlled not",
-            "numberOfQubits": 3,
-            "semantics": [],
-            "icon":
-            {
-                "base": "C-CNOT"
             }
         },
         "_wait":
@@ -1245,7 +1079,6 @@
             "CR": "_CR",
             "CRk": "_CRk",
             "CZ": "_CZ",
-            "Fredkin": "_Fredkin",
             "H": "_H",
             "I": "_I",
             "Rx": "_Rx",
@@ -1253,10 +1086,8 @@
             "Rz": "_Rz",
             "S": "_S",
             "Sdag": "_Sdag",
-            "sqrtSWAP": "_sqrtSWAP",
             "SWAP": "_SWAP",
             "T": "_T",
-            "Toffoli": "_Toffoli",
             "Tdag": "_Tdag",
             "X": "_X",
             "X90": "_X90",
@@ -1269,17 +1100,8 @@
         "nonUnitary":
         {
             "init": "_init",
-            "init_X": "_init_X",
-            "init_Y": "_init_Y",
-            "init_Z": "_init_Z",
             "measure": "_measure",
-            "measure_X": "_measure_X",
-            "measure_Y": "_measure_Y",
-            "measure_Z": "_measure_Z",
-            "reset": "_reset",
-            "reset_X": "_reset_X",
-            "reset_Y": "_reset_Y",
-            "reset_Z": "_reset_Z"
+            "reset": "_reset"
         },
         "directive":
         {

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -4,7 +4,7 @@
         "_barrier":
         {
             "title": "Barrier",
-            "description": "Barrier directive",
+            "description": "Barrier control instruction",
             "numberOfQubits": 1,
             "icon":
             {
@@ -824,7 +824,7 @@
         "_wait":
         {
             "title": "Wait",
-            "description": "Wait directive",
+            "description": "Wait control instruction",
             "numberOfQubits": 1,
             "icon":
             {
@@ -1103,7 +1103,7 @@
             "measure": "_measure",
             "reset": "_reset"
         },
-        "directive":
+        "control":
         {
             "barrier": "_barrier",
             "wait": "_wait"

--- a/quis/quis.json
+++ b/quis/quis.json
@@ -1,6 +1,16 @@
 {
     "descriptions":
     {
+        "_barrier":
+        {
+            "title": "Barrier",
+            "description": "Barrier directive",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "barrier"
+            }
+        },
         "_CNOT":
         {
             "title": "CNOT gate",
@@ -43,7 +53,8 @@
             ],
             "icon":
             {
-                "base": "controlled"
+                "base": "controlled",
+                "targetGate": "_P"
             }
         },
         "_CRk":
@@ -68,7 +79,8 @@
             ],
             "icon":
             {
-                "base": "controlled"
+                "base": "controlled",
+                "targetGate": "_Pk"
             }
         },
         "_CZ":
@@ -88,7 +100,19 @@
             ],
             "icon":
             {
-                "base": "controlled"
+                "base": "controlled",
+                "targetGate": "_Z"
+            }
+        },
+        "_Fredkin":
+        {
+            "title": "Fredkin gate",
+           "description": "Controlled SWAP",
+            "numberOfQubits": 3,
+            "semantics": [],
+            "icon":
+            {
+                "base": "C-SWAP"
             }
         },
         "_H":
@@ -159,6 +183,210 @@
             "icon":
             {
                 "base": "I"
+            }
+        },
+        "_init":
+        {
+            "title": "Init",
+            "description": "Initializes qubits in the Z-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "init"
+            }
+        },
+        "_init_X":
+        {
+            "title": "Init-X",
+            "description": "Initializes qubits in the X-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "init",
+                "suffix": {
+                    "subscript": "X"
+                }
+            }
+        },
+        "_init_Y":
+        {
+            "title": "Init-Y",
+            "description": "Initializes qubits in the Y-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "init",
+                "suffix": {
+                    "subscript": "Y"
+                }
+            }
+        },
+        "_init_Z":
+        {
+            "title": "Init-Z",
+            "description": "Initializes qubits in the Z-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "init",
+                "suffix": {
+                    "subscript": "Z"
+                }
+            }
+        },
+        "_measure":
+        {
+            "title": "Measure",
+            "description": "Measurement of the qubit in the Z-basis",
+            "icon":
+            {
+                "base": "measure"
+            }
+        },
+        "_measure_X":
+        {
+            "title": "Measure-X",
+            "description": "Measurement of the qubit in the X-basis",
+            "icon":
+            {
+                "base": "measure",
+                "suffix": {
+                    "subscript": "X"
+                }
+            }
+        },
+        "_measure_Y":
+        {
+            "title": "Measure-Y",
+            "description": "Measurement of the qubit in the Y-basis",
+            "icon":
+            {
+                "base": "measure",
+                "suffix": {
+                    "subscript": "Y"
+                }
+            }
+        },
+        "_measure_Z":
+        {
+            "title": "Measure-Z",
+            "description": "Measurement of the qubit in the Z-basis",
+            "icon":
+            {
+                "base": "measure",
+                "suffix": {
+                    "subscript": "Z"
+                }
+            }
+        },
+        "_mX90":
+        {
+            "title": "X-minus-90 gate",
+            "description": "A clockwise rotation of $\\pi/2$ radians about the _x_-axis.",
+            "numberOfQubits": 1,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            1,
+                            0,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi"
+                                },
+                                -2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi"
+                                },
+                                -4
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "X",
+                "suffix":
+                {
+                    "superscript": "minushalf"
+                }
+            }
+        },
+        "_mY90":
+        {
+            "title": "Y-minus-90 gate",
+            "description": "A clockwise rotation of $\\pi/2$ radians about the _y_-axis.",
+            "numberOfQubits": 1,
+            "semantics":
+            [
+                {
+                    "type": "blochSphereRotation",
+                    "args":
+                    {
+                        "axis":
+                        [
+                            0,
+                            1,
+                            0
+                        ],
+                        "angle":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi"
+                                },
+                                -2
+                            ]
+                        },
+                        "globalPhase":
+                        {
+                            "type": "operator",
+                            "value": "frac",
+                            "args":
+                            [
+                                {
+                                    "type": "constant",
+                                    "value": "pi"
+                                },
+                                -4
+                            ]
+                        }
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "Y",
+                "suffix":
+                {
+                    "superscript": "minushalf"
+                }
             }
         },
         "_P":
@@ -302,6 +530,55 @@
                 "suffix":
                 {
                     "subscript": "k"
+                }
+            }
+        },
+        "_reset":
+        {
+            "title": "Reset",
+            "description": "Resets qubit to ground state in the Z-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "reset"
+            }
+        },
+        "_reset_X":
+        {
+            "title": "Reset-X",
+            "description": "Resets qubit to ground state in the X-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "reset",
+                "suffix": {
+                    "subscript": "X"
+                }
+            }
+        },
+        "_reset_Y":
+        {
+            "title": "Reset-Y",
+            "description": "Resets qubit to ground state in the Y-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "reset",
+                "suffix": {
+                    "subscript": "Y"
+                }
+            }
+        },
+        "_reset_Z":
+        {
+            "title": "Reset-Z",
+            "description": "Resets qubit to ground state in the Z-basis",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "reset",
+                "suffix": {
+                    "subscript": "Z"
                 }
             }
         },
@@ -537,6 +814,62 @@
                 }
             }
         },
+        "_sqrtSWAP":
+        {
+            "title": "sqrtSWAP gate",
+            "description": "Square root of SWAPs.",
+            "numberOfQubits": 2,
+            "semantics":
+            [
+                {
+                    "type": "matrixGate",
+                    "args":
+                    {
+                        "matrix":
+                        [
+                            [1, 0, 0, 0],
+                            [0, (1 + i) / 2, (1 - i) / 2, 0],
+                            [0, (1 - i) / 2, (1 + i) / 2, 0],
+                            [0, 0, 0, 1]
+                        ]
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "SWAP",
+                "suffix":
+                {
+                    "superscript": "half"
+                }
+            }
+        },
+        "_SWAP":
+        {
+            "title": "SWAP gate",
+            "description": "SWAPs.",
+            "numberOfQubits": 2,
+            "semantics":
+            [
+                {
+                    "type": "matrixGate",
+                    "args":
+                    {
+                        "matrix":
+                        [
+                            [1, 0, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 1]
+                        ]
+                    }
+                }
+            ],
+            "icon":
+            {
+                "base": "swap",
+            }
+        },
         "_T":
         {
             "title": "T gate",
@@ -641,6 +974,27 @@
                 {
                     "superscript": "dagger"
                 }
+            }
+        },
+        "_Toffoli":
+        {
+            "title": "Toffoli gate",
+           "description": "Controlled controlled not",
+            "numberOfQubits": 3,
+            "semantics": [],
+            "icon":
+            {
+                "base": "C-CNOT"
+            }
+        },
+        "_wait":
+        {
+            "title": "Wait",
+            "description": "Wait directive",
+            "numberOfQubits": 1,
+            "icon":
+            {
+                "base": "wait"
             }
         },
         "_X":
@@ -881,135 +1235,6 @@
             {
                 "base": "Z"
             }
-        },
-        "_mX90":
-        {
-            "title": "X-minus-90 gate",
-            "description": "A clockwise rotation of $\\pi/2$ radians about the _x_-axis.",
-            "numberOfQubits": 1,
-            "semantics":
-            [
-                {
-                    "type": "blochSphereRotation",
-                    "args":
-                    {
-                        "axis":
-                        [
-                            1,
-                            0,
-                            0
-                        ],
-                        "angle":
-                        {
-                            "type": "operator",
-                            "value": "frac",
-                            "args":
-                            [
-                                {
-                                    "type": "constant",
-                                    "value": "pi"
-                                },
-                                -2
-                            ]
-                        },
-                        "globalPhase":
-                        {
-                            "type": "operator",
-                            "value": "frac",
-                            "args":
-                            [
-                                {
-                                    "type": "constant",
-                                    "value": "pi"
-                                },
-                                -4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "X",
-                "suffix":
-                {
-                    "superscript": "minushalf"
-                }
-            }
-        },
-        "_mY90":
-        {
-            "title": "Y-minus-90 gate",
-            "description": "A clockwise rotation of $\\pi/2$ radians about the _y_-axis.",
-            "numberOfQubits": 1,
-            "semantics":
-            [
-                {
-                    "type": "blochSphereRotation",
-                    "args":
-                    {
-                        "axis":
-                        [
-                            0,
-                            1,
-                            0
-                        ],
-                        "angle":
-                        {
-                            "type": "operator",
-                            "value": "frac",
-                            "args":
-                            [
-                                {
-                                    "type": "constant",
-                                    "value": "pi"
-                                },
-                                -2
-                            ]
-                        },
-                        "globalPhase":
-                        {
-                            "type": "operator",
-                            "value": "frac",
-                            "args":
-                            [
-                                {
-                                    "type": "constant",
-                                    "value": "pi"
-                                },
-                                -4
-                            ]
-                        }
-                    }
-                }
-            ],
-            "icon":
-            {
-                "base": "Y",
-                "suffix":
-                {
-                    "superscript": "minushalf"
-                }
-            }
-        },
-        "_measure":
-        {
-            "title": "Measure",
-            "description": "Measurement of the qubit in the Z-basis",
-            "icon":
-            {
-                "base": "measure"
-            }
-        },
-        "_reset":
-        {
-            "title": "Reset",
-            "description": "Resets qubit to ground state in the Z-basis",
-            "numberOfQubits": 1,
-            "icon":
-            {
-                "base": "reset"
-            }
         }
     },
     "instructions":
@@ -1020,6 +1245,7 @@
             "CR": "_CR",
             "CRk": "_CRk",
             "CZ": "_CZ",
+            "Fredkin": "_Fredkin",
             "H": "_H",
             "I": "_I",
             "Rx": "_Rx",
@@ -1027,7 +1253,10 @@
             "Rz": "_Rz",
             "S": "_S",
             "Sdag": "_Sdag",
+            "sqrtSWAP": "_sqrtSWAP",
+            "SWAP": "_SWAP",
             "T": "_T",
+            "Toffoli": "_Toffoli",
             "Tdag": "_Tdag",
             "X": "_X",
             "X90": "_X90",
@@ -1039,8 +1268,23 @@
         },
         "nonUnitary":
         {
+            "init": "_init",
+            "init_X": "_init_X",
+            "init_Y": "_init_Y",
+            "init_Z": "_init_Z",
             "measure": "_measure",
-            "reset": "_reset"
+            "measure_X": "_measure_X",
+            "measure_Y": "_measure_Y",
+            "measure_Z": "_measure_Z",
+            "reset": "_reset",
+            "reset_X": "_reset_X",
+            "reset_Y": "_reset_Y",
+            "reset_Z": "_reset_Z"
+        },
+        "directive":
+        {
+            "barrier": "_barrier",
+            "wait": "_wait"
         }
     }
 }


### PR DESCRIPTION
- Instructions added:
  - init
  - swap
  - barrier
  - wait
- `targetGate` field added to icon description of controlled gates
- Descriptions alphabetized 
